### PR TITLE
feat: optional API key auth for OpenAI endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ for chunk in response:
 | 环境变量 | 默认值 | 说明 |
 |---------|--------|------|
 | `PORT` | `9090` | 服务器监听端口 |
+| `API_KEY` | - | （可选）启用 OpenAI 风格鉴权，要求 `Authorization: Bearer <API_KEY>` |
 | `DEBUG` | - | 设置任意值开启调试日志 |
 
 ### 扩展

--- a/server.py
+++ b/server.py
@@ -41,6 +41,7 @@ log = logging.getLogger("arena2api")
 # 配置
 # ============================================================
 PORT = int(os.environ.get("PORT", "9090"))
+API_KEY = os.environ.get("API_KEY", "").strip()
 ARENA_BASE = "https://arena.ai"
 ARENA_CREATE_EVAL = f"{ARENA_BASE}/nextjs-api/stream/create-evaluation"
 ARENA_POST_EVAL = f"{ARENA_BASE}/nextjs-api/stream/post-to-evaluation"  # + /{id}
@@ -194,6 +195,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+def verify_api_key(request: Request):
+    """Optional API key auth for OpenAI endpoints.
+
+    If API_KEY is set, require: Authorization: Bearer <API_KEY>
+    """
+    if not API_KEY:
+        return
+
+    auth_header = request.headers.get("authorization", "")
+    expected = f"Bearer {API_KEY}"
+    if auth_header != expected:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
 
 # ============================================================
 # 扩展端点
@@ -223,8 +237,9 @@ async def extension_status():
 # OpenAI 兼容端点
 # ============================================================
 @app.get("/v1/models")
-async def list_models():
+async def list_models(request: Request):
     """列出可用模型"""
+    verify_api_key(request)
     all_models = {}
     all_models.update(store.text_models)
     all_models.update(store.image_models)
@@ -265,6 +280,7 @@ def detect_client(request: Request) -> str:
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):
     """OpenAI 兼容的聊天补全"""
+    verify_api_key(request)
     try:
         body = await request.json()
     except Exception:


### PR DESCRIPTION
## Summary
- add optional `API_KEY` env var
- when set, require `Authorization: Bearer <API_KEY>` on `/v1/models` and `/v1/chat/completions`
- keep extension endpoints (`/v1/extension/*`) unchanged for browser extension compatibility
- document `API_KEY` in README config table

## Why
By default the proxy is often deployed behind reverse proxies or local ports. This change provides a built-in OpenAI-style auth layer for direct deployments without breaking existing setups.

## Backward compatibility
- No behavior change when `API_KEY` is not set
